### PR TITLE
fix(vue): correct typo in resolveCodeFeatures patch

### DIFF
--- a/packages/vue/src/patch-language-tools.ts
+++ b/packages/vue/src/patch-language-tools.ts
@@ -36,7 +36,7 @@ patchFile('@vue/language-core/lib/codegen/template/context.js', (src) => {
 		const data = stack.at(-1)
 		if (data?.expectError != null) {
 			features = {
-				...feature,
+				...features,
 				__expectErrorCommentLoc: [
 					(options?.template?.startTagEnd ?? 0) + data.expectError.node.loc.start.offset,
 					(options?.template?.startTagEnd ?? 0) + data.expectError.node.loc.end.offset,


### PR DESCRIPTION
Hi @auvred.

Ran `golar` on our project, and we get the following (non-blocking) run-time error:

```
ReferenceError: feature is not defined
    at Object.resolveCodeFeatures
```

It seems like a small typo, see below more context 🙏 

----------------

## Summary

- Fix `ReferenceError: feature is not defined` in `patch-language-tools.ts`
- The `resolveCodeFeatures` wrapper spreads `...feature` (undefined) instead of `...features` (the local variable declared on the line above)
- This error triggers whenever golar processes a `.vue` file with a `@vue-expect-error` directive in its template

## Reproduction

1. Run `golar --noEmit` on a Vue project that has `.vue` files using `@vue-expect-error` in templates
2. Observe: `ReferenceError: feature is not defined` at `patch-language-tools.js`

## Fix

One-character change: `...feature,` → `...features,` in the patched `resolveCodeFeatures` function.