### PR TITLE
chore: pin minimum required Node.js version

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,9 @@
 {
 	"type": "module",
 	"private": true,
+	"engines": {
+		"node": ">=22.12.0"
+	},
 	"scripts": {
 		"dev": "astro dev",
 		"start": "astro dev",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 	"packageManager": "pnpm@10.28.0",
 	"type": "module",
 	"private": true,
+	"engines": {
+		"node": ">=22.12.0"
+	},
 	"version": "0.1.3",
 	"scripts": {
 		"check": "golar",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -2,6 +2,9 @@
 	"name": "@golar/astro",
 	"version": "0.1.3",
 	"type": "module",
+	"engines": {
+		"node": ">=22.12.0"
+	},
 	"exports": {
 		".": "./src/index.ts"
 	},

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -2,6 +2,9 @@
 	"name": "@golar/ember",
 	"version": "0.1.3",
 	"type": "module",
+	"engines": {
+		"node": ">=22.12.0"
+	},
 	"exports": {
 		".": "./src/index.ts"
 	},

--- a/packages/golar/package.json
+++ b/packages/golar/package.json
@@ -2,6 +2,9 @@
 	"name": "golar",
 	"version": "0.1.3",
 	"type": "module",
+	"engines": {
+		"node": ">=22.12.0"
+	},
 	"bin": "./src/bin.ts",
 	"exports": {
 		"./unstable": "./src/unstable.ts",

--- a/packages/sourcemap/package.json
+++ b/packages/sourcemap/package.json
@@ -2,6 +2,9 @@
 	"name": "@golar/sourcemap",
 	"version": "0.1.3",
 	"type": "module",
+	"engines": {
+		"node": ">=22.12.0"
+	},
 	"exports": {
 		".": "./src/index.ts"
 	},

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -2,6 +2,9 @@
 	"name": "@golar/svelte",
 	"version": "0.1.3",
 	"type": "module",
+	"engines": {
+		"node": ">=22.12.0"
+	},
 	"exports": {
 		".": "./src/index.ts"
 	},

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -2,6 +2,9 @@
 	"name": "@golar/util",
 	"version": "0.1.3",
 	"type": "module",
+	"engines": {
+		"node": ">=22.12.0"
+	},
 	"exports": {
 		".": "./src/index.ts"
 	},

--- a/packages/volar/package.json
+++ b/packages/volar/package.json
@@ -2,6 +2,9 @@
 	"name": "@golar/volar",
 	"version": "0.1.3",
 	"type": "module",
+	"engines": {
+		"node": ">=22.12.0"
+	},
 	"exports": {
 		".": "./src/index.ts"
 	},

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -2,6 +2,9 @@
 	"name": "@golar/vue",
 	"version": "0.1.3",
 	"type": "module",
+	"engines": {
+		"node": ">=22.12.0"
+	},
 	"exports": {
 		".": "./src/index.ts"
 	},


### PR DESCRIPTION
resolves https://github.com/auvred/golar/issues/14

Why `>=22.12.0`? It's the closest Node version in maintenance mode, which is commonly used in the community and not too aggressive (like directly requiring Node 24). It also aligns with the project's actual situation and meets the requirements of the [Astro v6](https://github.com/withastro/astro/blob/main/package.json#L57) used.