### PR TITLE
chore: mark ast file as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto eol=lf
+
+crates/golar/src/*_generated linguist-generated=true


### PR DESCRIPTION
I was taking a look to see how Golar was chugging along and noticed GitHub classifies it as a "Rust" project now, when that's not really true. This should fix that.