### PR TITLE
chore: strip release binaries

### DIFF
--- a/tools/build.ts
+++ b/tools/build.ts
@@ -18,7 +18,7 @@ const release = args.includes('release')
 const putToBin = args.includes('put-to-bin')
 
 const goDebug = debug ? ['-gcflags', 'all=-N -l'] : []
-const goRelease = release ? ['-trimpath'] : []
+const goRelease = release ? ['-ldflags', '-s -w', '-trimpath'] : []
 
 const libc =
 	process.env.GOLAR_LIBC === 'musl' || (await libcFamily()) === MUSL


### PR DESCRIPTION
Inspired by https://github.com/oxc-project/tsgolint/pull/1049 and https://github.com/yuku-toolchain/yuku/pull/100.

Wasn't trying to test this on my own machine 😅, Amp reports these savings:

| Artifact | Before | After | Reduction |
|---|---:|---:|---:|
| `golar.node` | 32,176,904 B | 24,231,288 B | **7,945,616 B (24.69%)** |
| `golar.node.gz` | 13,547,967 B | 8,001,790 B | **5,546,177 B (40.94%)** |
| `golar-astro` | 7,041,740 B | 5,107,874 B | **1,933,866 B (27.46%)** |
| `golar-astro.gz` | 4,464,825 B | 2,791,850 B | **1,672,975 B (37.47%)** |